### PR TITLE
fix bug regex when one query is included in another

### DIFF
--- a/src/af_analysis/format/colabfold_1_5.py
+++ b/src/af_analysis/format/colabfold_1_5.py
@@ -129,7 +129,7 @@ def add_pdb(log_pd, directory, verbose=True):
 
     for _, row in tqdm(log_pd.iterrows(), total=log_pd.shape[0], disable=disable):
         # reg = fr"{row['query']}_.*_{row['weight']}_model_{row['model']}_seed_{row['seed']:03d}\.r{row['recycle']}\.pdb"
-        reg = rf"{row['query']}.*_{row['weight']}_model_{row['model']}_seed_{row['seed']:03d}\.pdb"
+        reg = rf"{row['query']}_.*_{row['weight']}_model_{row['model']}_seed_{row['seed']:03d}\.pdb"
         r = re.compile(reg)
         res = list(filter(r.match, file_list))
 


### PR DESCRIPTION
Before, data loading failed with error ValueError: Length of values (1235) does not match length of index (1215), because of one query contained in another query
For instance:
Q15116_Q9NZQ7_segment_14_design_1_unrelaxed_rank_001_alphafold2_multimer_v3_model_2_seed_000.pdb
Q15116_Q9NZQ7_segment_14_design_10_unrelaxed_rank_001_alphafold2_multimer_v3_model_2_seed_000.pdb

Adding underscore in the regex now works fine for me